### PR TITLE
feat: Added bind/port server flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,27 @@ When you first run Captain, if no user exists, you'll be guided through a setup 
 
 1. Run Captain:
    ```sh
-   captain
+   captain run
    ```
+
+   Available flags:
+   - `-b, --bind`: Address to bind to (overrides config)
+   - `-p, --port`: Server port (overrides config)
+   - `-i, --init-dev-db`: Initialize development database with test data
+   - `-c, --config`: Config file path
+
+   Examples:
+   ```sh
+   # Run with default settings
+   captain run
+
+   # Bind to all interfaces on port 3000
+   captain run -b 0.0.0.0 -p 3000
+
+   # Use custom config and initialize test data
+   captain run -c /path/to/config.yaml -i
+   ```
+
 2. Follow the setup wizard prompts to create your admin account
 3. Access the admin interface at http://localhost:8080/admin
 4. Start writing!
@@ -102,11 +121,22 @@ This will:
 - Set GORM's log level to info for detailed SQL logging
 - Display more detailed error messages
 
-You can also initialize the database with test data using the `-i` flag:
+You can also:
+- Initialize the database with test data using `-i`
+- Change the bind address with `-b`
+- Change the port with `-p`
 
+Examples:
 ```bash
+# Run in dev mode with test data
 make run_dev
 ./dist/bin/captain-darwin-amd64 run -i
+
+# Run on a different port
+./dist/bin/captain-darwin-amd64 run -p 3000
+
+# Bind to all interfaces
+./dist/bin/captain-darwin-amd64 run -b 0.0.0.0
 ```
 
 For production use, use the standard `make run` command which disables debug mode.

--- a/main.go
+++ b/main.go
@@ -29,6 +29,8 @@ var embeddedFS embed.FS
 var (
 	initDevDB  bool
 	configFile string
+	serverHost string
+	serverPort int
 )
 
 func main() {
@@ -53,6 +55,8 @@ func main() {
 	}
 
 	runCmd.Flags().BoolVarP(&initDevDB, "init-dev-db", "i", false, "Initialize the development database with test data")
+	runCmd.Flags().StringVarP(&serverHost, "bind", "b", "", "Address to bind to (overrides config)")
+	runCmd.Flags().IntVarP(&serverPort, "port", "p", 0, "Server port (overrides config)")
 
 	var userCmd = &cobra.Command{
 		Use:   "user",
@@ -85,6 +89,14 @@ func runServer(cmd *cobra.Command, args []string) {
 	cfg, err := config.InitConfig()
 	if err != nil {
 		log.Fatalf("Error loading config: %v", err)
+	}
+
+	// Override config with command line flags if provided
+	if serverHost != "" {
+		cfg.Server.Host = serverHost
+	}
+	if serverPort != 0 {
+		cfg.Server.Port = serverPort
 	}
 
 	// Set Gin mode based on debug flag


### PR DESCRIPTION
# Add Bind Address and Port Flags

This PR adds command-line flags to override the server's bind address and port without modifying the config file.

## Changes

1. Added new command-line flags to the ` run` command:
   - `-b/--bind`: Override the address to bind to (defaults to config's server.host)
   - `-p/--port`: Override the server port (defaults to config's server.port)

2. Added logic in `runServer` to:
   - Load default values from config file
   - Override config values when flags are provided
   - Maintain existing behavior when flags are not used

## Usage Examples

```bash
# Use default bind/port from config
captain run

# Override port only
captain run -p 3000

# Override bind address only
captain run -b 0.0.0.0

# Override both
captain run -b 0.0.0.0 -p 3000
