### PR TITLE
fix: Handle long filenames

### DIFF
--- a/handlers/media.go
+++ b/handlers/media.go
@@ -62,7 +62,7 @@ func ServeMedia(database *gorm.DB, cfg *config.Config) gin.HandlerFunc {
 
 		// Set content type header
 		c.Header("Content-Type", media.MimeType)
-		c.Header("Content-Disposition", fmt.Sprintf("inline; filename=%s", media.Name))
+		c.Header("Content-Disposition", fmt.Sprintf("inline; filename=%s", path))
 
 		// Stream the file to the response
 		if _, err := io.Copy(c.Writer, file); err != nil {

--- a/storage/local.go
+++ b/storage/local.go
@@ -25,9 +25,10 @@ func NewLocalProvider(baseDir string) (*LocalProvider, error) {
 
 // Save implements Provider.Save
 func (p *LocalProvider) Save(file *multipart.FileHeader) (string, error) {
-	// Generate unique filename
+	// Generate unique filename with slugified name
 	ext := filepath.Ext(file.Filename)
-	filename := fmt.Sprintf("%d-%s%s", time.Now().Unix(), file.Filename[:len(file.Filename)-len(ext)], ext)
+	name := file.Filename[:len(file.Filename)-len(ext)]
+	filename := fmt.Sprintf("%d-%s%s", time.Now().Unix(), slugify(name), ext)
 	filepath := filepath.Join(p.baseDir, filename)
 
 	// Open source file

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -62,9 +62,10 @@ func NewS3Provider(bucket, region, endpoint, access_key, secret_key string) (*S3
 
 // Save implements Provider.Save
 func (p *S3Provider) Save(file *multipart.FileHeader) (string, error) {
-	// Generate unique filename
+	// Generate unique filename with slugified name
 	ext := filepath.Ext(file.Filename)
-	filename := fmt.Sprintf("%d-%s%s", time.Now().Unix(), file.Filename[:len(file.Filename)-len(ext)], ext)
+	name := file.Filename[:len(file.Filename)-len(ext)]
+	filename := fmt.Sprintf("%d-%s%s", time.Now().Unix(), slugify(name), ext)
 
 	// Open source file
 	src, err := file.Open()

--- a/storage/utils.go
+++ b/storage/utils.go
@@ -1,0 +1,45 @@
+package storage
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	// nonAlphanumericRegex matches any character that is not alphanumeric, dash, or underscore
+	nonAlphanumericRegex = regexp.MustCompile(`[^a-zA-Z0-9-_]`)
+	// multiDashRegex matches multiple consecutive dashes
+	multiDashRegex = regexp.MustCompile(`-+`)
+)
+
+// slugify converts a filename into a URL-friendly slug
+// It removes special characters, replaces spaces with dashes, and ensures the result is safe for URLs
+// The result is limited to 50 characters
+func slugify(filename string) string {
+	// Convert to lowercase
+	slug := strings.ToLower(filename)
+
+	// Replace any non-alphanumeric character with a dash
+	slug = nonAlphanumericRegex.ReplaceAllString(slug, "-")
+
+	// Replace multiple consecutive dashes with a single dash
+	slug = multiDashRegex.ReplaceAllString(slug, "-")
+
+	// Remove leading and trailing dashes
+	slug = strings.Trim(slug, "-")
+
+	// Limit to 50 characters, but don't cut in the middle of a word if possible
+	if len(slug) > 50 {
+		// Try to find the last dash before the 50th character
+		lastDash := strings.LastIndex(slug[:50], "-")
+		if lastDash > 0 {
+			// Cut at the last dash
+			slug = slug[:lastDash]
+		} else {
+			// If no dash found, just cut at 50
+			slug = slug[:50]
+		}
+	}
+
+	return slug
+}


### PR DESCRIPTION
When serving media the Content-Disposition header was overflowing when the filename was long.
We now slugify the filename, keep it under 50 chars and use that in the header value