### PR TITLE
feat: S3 config sanity check

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -203,3 +203,31 @@ func (c *Config) GetTimezones() []string {
 func (c *Config) GetChromaStyles() []string {
 	return chromaStyles
 }
+
+// ValidateS3Config validates S3 configuration if S3 provider is selected
+func (c *Config) ValidateS3Config() error {
+	if c.Storage.Provider != "s3" {
+		return nil
+	}
+
+	var missingFields []string
+
+	if c.Storage.S3.Bucket == "" {
+		missingFields = append(missingFields, "storage.s3.bucket")
+	}
+	if c.Storage.S3.Region == "" {
+		missingFields = append(missingFields, "storage.s3.region")
+	}
+	if c.Storage.S3.AccessKey == "" {
+		missingFields = append(missingFields, "storage.s3.access_key")
+	}
+	if c.Storage.S3.SecretKey == "" {
+		missingFields = append(missingFields, "storage.s3.secret_key")
+	}
+
+	if len(missingFields) > 0 {
+		return fmt.Errorf("missing required S3 configuration fields: %v", missingFields)
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -120,6 +120,11 @@ func runServer(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	// Validate S3 configuration if S3 provider is selected
+	if err := cfg.ValidateS3Config(); err != nil {
+		log.Fatalf("S3 configuration error: %v", err)
+	}
+
 	// Create and start server
 	srv := server.New(database, cfg, embeddedFS)
 


### PR DESCRIPTION
**_Prompt:_**

Prevent Captain from starting if storarage.provider is "s3" and one mandatory s3 configuration option is missing