### PR TITLE
fix: Fixed post published_at display in admin

### DIFF
--- a/handlers/admin_posts.go
+++ b/handlers/admin_posts.go
@@ -20,6 +20,24 @@ func (h *AdminHandlers) ListPosts(c *gin.Context) {
 		return
 	}
 
+	// Get settings for timezone
+	settings, err := db.GetSettings(h.db)
+	if err != nil {
+		c.HTML(http.StatusInternalServerError, "500.tmpl", h.addCommonData(c, gin.H{}))
+		return
+	}
+
+	// Load timezone from settings
+	loc, err := time.LoadLocation(settings.Timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+
+	// Convert post times to user timezone
+	for i := range posts {
+		posts[i].PublishedAt = posts[i].PublishedAt.In(loc)
+	}
+
 	c.HTML(http.StatusOK, "admin_posts.tmpl", h.addCommonData(c, gin.H{
 		"title": "Posts",
 		"posts": posts,
@@ -202,8 +220,26 @@ func (h *AdminHandlers) ListPostsByTag(c *gin.Context) {
 		return
 	}
 
+	// Get settings for timezone
+	settings, err := db.GetSettings(h.db)
+	if err != nil {
+		c.HTML(http.StatusInternalServerError, "500.tmpl", h.addCommonData(c, gin.H{}))
+		return
+	}
+
+	// Load timezone from settings
+	loc, err := time.LoadLocation(settings.Timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+
+	// Convert post times to user timezone
+	for i := range posts {
+		posts[i].PublishedAt = posts[i].PublishedAt.In(loc)
+	}
+
 	c.HTML(http.StatusOK, "admin_tag_posts.tmpl", h.addCommonData(c, gin.H{
-		"title": "Posts",
+		"title": fmt.Sprintf("Posts tagged with '%s'", tag.Name),
 		"posts": posts,
 		"tag":   tag,
 	}))
@@ -273,6 +309,22 @@ func (h *AdminHandlers) EditPost(c *gin.Context) {
 		c.HTML(http.StatusInternalServerError, "500.tmpl", h.addCommonData(c, gin.H{}))
 		return
 	}
+
+	// Get settings for timezone
+	settings, err := db.GetSettings(h.db)
+	if err != nil {
+		c.HTML(http.StatusInternalServerError, "500.tmpl", h.addCommonData(c, gin.H{}))
+		return
+	}
+
+	// Load timezone from settings
+	loc, err := time.LoadLocation(settings.Timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+
+	// Convert post time to user timezone
+	post.PublishedAt = post.PublishedAt.In(loc)
 
 	c.HTML(http.StatusOK, "admin_edit_post.tmpl", h.addCommonData(c, gin.H{
 		"title":    "Edit Post",


### PR DESCRIPTION
# Pull Request

## AI Information
**AI used**: Yes
**Editor used**: Windsurf 1.1.0
*Model used**: Claude 3.5 Sonnet

## Prompts Used

### Prompt 1:
```
In @admin_posts.go there's an issue with the way published_at is handled:

- When listing the posts with display the UTC (what's stored in the database) instead of the time at the selected timezone (from settings)

Also when editing, I created a post with New york timezone to be published at 12:10 my time, it was correctly created at 17:10 UTC, but when editing the post it shows that published date is set to 22:10 my time
```

### Prompt 2:
```
Do the same when listing posts for a given tag
```

### Prompt 3:
```
Please run `make test` and fix the tests
```

## Description

There was a problem when displaying posts and editing them. The time was not merged with the Timezone settings meaning that it was always displaying the UTC time.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
