### PR TITLE
chore: Make sure go 1.23 is used and bumped upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.23'
 
     - name: Install golangci-lint
       run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
@@ -51,7 +51,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.23'
 
     - name: Set up Node.js
       uses: actions/setup-node@v3
@@ -79,7 +79,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: playwright-report
         path: playwright-report/


### PR DESCRIPTION
# Pull Request

## AI Information
**AI used**: No
**Editor used**: Windsurf 1.1.0

## Description
Following the [deprecation notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) of upload-artifact, bumped its version to v4.
Also align go versions to 1.23 instead of 1.21


## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
