### PR TITLE
feat: Add flash message middleware and framework

### DIFF
--- a/e2e/specs/admin.spec.ts
+++ b/e2e/specs/admin.spec.ts
@@ -87,6 +87,9 @@ test.describe('Admin Panel E2E Tests', () => {
 
             await page.click('button:has-text("Create Post")');
             
+            // Verify flash message
+            await expect(page.locator('.flash-message.flash-success')).toBeVisible();
+            await expect(page.locator('.flash-message.flash-success')).toContainText('Post created successfully');
             
             // Verify post creation
             await expect(page.locator(`text=${postTitle}`)).toBeVisible();

--- a/embedded/admin/static/css/admin.css
+++ b/embedded/admin/static/css/admin.css
@@ -978,7 +978,84 @@ a:hover {
     content: "⚠️";
 }
 
+/* Flash Messages */
+.flash-messages {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 1000;
+    max-width: 400px;
+}
 
+.flash-message {
+    padding: 15px;
+    margin-bottom: 10px;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    animation: slideIn 0.3s ease-out;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.flash-message .message-text {
+    flex: 1;
+}
+
+.flash-message .dismiss-button {
+    background: none;
+    border: none;
+    color: inherit;
+    opacity: 0.7;
+    cursor: pointer;
+    padding: 0 0 0 10px;
+    font-size: 14px;
+}
+
+.flash-message .dismiss-button:hover {
+    opacity: 1;
+}
+
+.flash-debug {
+    background-color: #e3e3e3;
+    color: #333;
+    border-left: 4px solid #666;
+}
+
+.flash-info {
+    background-color: #e3f2fd;
+    color: #0d47a1;
+    border-left: 4px solid #2196f3;
+}
+
+.flash-success {
+    background-color: #e8f5e9;
+    color: #1b5e20;
+    border-left: 4px solid #4caf50;
+}
+
+.flash-warning {
+    background-color: #fff3e0;
+    color: #e65100;
+    border-left: 4px solid #ff9800;
+}
+
+.flash-error {
+    background-color: #ffebee;
+    color: #b71c1c;
+    border-left: 4px solid #f44336;
+}
+
+@keyframes slideIn {
+    from {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
 
 @media (max-width: 768px) {
     .admin-container {

--- a/embedded/admin/static/js/admin.js
+++ b/embedded/admin/static/js/admin.js
@@ -1,18 +1,12 @@
 function deleteTag(id) {
     fetch(`/admin/tags/${id}`, {
         method: 'DELETE',
-    }).then((response) => {
-        if (response.ok) {
-            window.location.href = '/admin/tags';
-        } else {
-            response.json().then(data => {
-                showError(data.error || 'Failed to delete tag');
-            }).catch(() => {
-                showError('Failed to delete tag');
-            });
+    }).then((response) => response.json())
+    .then((data) => {
+        if (data.redirect) {
+            window.location.href = data.redirect;
         }
     }).catch(error => {
-        showError('Failed to delete tag');
         console.error('Error:', error);
     });
 }
@@ -20,18 +14,12 @@ function deleteTag(id) {
 function deletePost(id) {
     fetch(`/admin/posts/${id}`, {
         method: 'DELETE',
-    }).then((response) => {
-        if (response.ok) {
-            window.location.href = '/admin/posts';
-        } else {
-            response.json().then(data => {
-                showError(data.error || 'Failed to delete post');
-            }).catch(() => {
-                showError('Failed to delete post');
-            });
+    }).then((response) => response.json())
+    .then((data) => {
+        if (data.redirect) {
+            window.location.href = data.redirect;
         }
     }).catch(error => {
-        showError('Failed to delete post');
         console.error('Error:', error);
     });
 }
@@ -39,18 +27,12 @@ function deletePost(id) {
 function deletePage(id) {
     fetch(`/admin/pages/${id}`, {
         method: 'DELETE',
-    }).then(response => {
-        if (response.ok) {
-            window.location.href = '/admin/pages';
-        } else {
-            response.json().then(data => {
-                showError(data.error || 'Failed to delete page');
-            }).catch(() => {
-                showError('Failed to delete page');
-            });
+    }).then((response) => response.json())
+    .then((data) => {
+        if (data.redirect) {
+            window.location.href = data.redirect;
         }
     }).catch(error => {
-        showError('Failed to delete page');
         console.error('Error:', error);
     });
 }
@@ -58,18 +40,12 @@ function deletePage(id) {
 function deleteMenuItem(id) {
     fetch(`/admin/menus/${id}`, {
         method: 'DELETE',
-    }).then(response => {
-        if (response.ok) {
-            window.location.href = '/admin/menus';
-        } else {
-            response.json().then(data => {
-                showError(data.error || 'Failed to delete menu item');
-            }).catch(() => {
-                showError('Failed to delete menu item');
-            });
+    }).then((response) => response.json())
+    .then((data) => {
+        if (data.redirect) {
+            window.location.href = data.redirect;
         }
     }).catch(error => {
-        showError('Failed to delete menu item');
         console.error('Error:', error);
     });
 }
@@ -77,37 +53,27 @@ function deleteMenuItem(id) {
 function deleteMedia(id) {
     fetch(`/admin/media/${id}`, {
         method: 'DELETE',
-    }).then((response) => {
-        if (response.ok) {
-            window.location.href = '/admin/media';
-        } else {
-            response.json().then(data => {
-                showError(data.error || 'Failed to delete media');
-            }).catch(() => {
-                showError('Failed to delete media');
-            });
+    }).then((response) => response.json())
+    .then((data) => {
+        if (data.redirect) {
+            window.location.href = data.redirect;
         }
     }).catch(error => {
-        showError('Failed to delete media');
         console.error('Error:', error);
     });
 }
 
-function showError(message) {
-    const errorDiv = document.createElement('div');
-    errorDiv.className = 'alert alert-error';
-    errorDiv.textContent = message;
-    
-    // Insert at the top of the main content area
-    const mainContent = document.querySelector('main');
-    if (mainContent) {
-        mainContent.insertBefore(errorDiv, mainContent.firstChild);
-    }
-    
-    // Remove after 5 seconds
-    setTimeout(() => {
-        errorDiv.remove();
-    }, 5000);
+function deleteUser(id) {
+    fetch(`/admin/users/${id}`, {
+        method: 'DELETE',
+    }).then((response) => response.json())
+    .then((data) => {
+        if (data.redirect) {
+            window.location.href = data.redirect;
+        }
+    }).catch(error => {
+        console.error('Error:', error);
+    });
 }
 
 function initializeEditor() {
@@ -421,13 +387,13 @@ function moveItem(id, direction) {
             window.location.reload();
         } else {
             response.json().then(data => {
-                showError(data.error || 'Failed to move item');
+                console.error(data.error || 'Failed to move item');
             }).catch(() => {
-                showError('Failed to move item');
+                console.error('Failed to move item');
             });
         }
     }).catch(error => {
-        showError('Failed to move item');
+        console.error('Failed to move item');
         console.error('Error:', error);
     });
 }

--- a/embedded/admin/templates/includes/admin_header.tmpl
+++ b/embedded/admin/templates/includes/admin_header.tmpl
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="/admin/static/css/admin.css">
 </head>
 <body>
+    {{ template "includes/flash_messages" . }}
     <button class="menu-toggle" id="menu-toggle">☰</button>
     <div class="admin-container">
         <nav class="admin-nav">

--- a/embedded/admin/templates/includes/flash_messages.tmpl
+++ b/embedded/admin/templates/includes/flash_messages.tmpl
@@ -1,0 +1,12 @@
+{{if .flashMessages}}
+<div class="flash-messages">
+    {{range .flashMessages}}
+    <div class="flash-message flash-{{.Severity.String | lower}}" role="alert">
+        <span class="message-text">{{.Text}}</span>
+        <button type="button" class="dismiss-button" onclick="this.parentElement.remove()">
+            <i class="fas fa-times"></i>
+        </button>
+    </div>
+    {{end}}
+</div>
+{{end}}

--- a/flash/flash.go
+++ b/flash/flash.go
@@ -1,0 +1,134 @@
+package flash
+
+import (
+	"fmt"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/session"
+)
+
+// Severity represents the severity level of a flash message
+type Severity string
+
+const (
+	DEBUG   Severity = "DEBUG"
+	INFO    Severity = "INFO"
+	SUCCESS Severity = "SUCCESS"
+	WARNING Severity = "WARNING"
+	ERROR   Severity = "ERROR"
+)
+
+// String implements the Stringer interface for Severity
+func (s Severity) String() string {
+	return string(s)
+}
+
+// Message represents a flash message
+type Message struct {
+	Text     string   `json:"text"`
+	Severity Severity `json:"severity"`
+}
+
+const flashKey = "flash_messages"
+
+var store *session.Store
+
+// Setup initializes the flash message system with a session store
+func Setup(s *session.Store) {
+	store = s
+	store.RegisterType([]Message{})
+}
+
+// AddMessage adds a flash message to the session
+func AddMessage(c *fiber.Ctx, severity Severity, text string) {
+	if store == nil {
+		// TODO: Log this
+		fmt.Println("flash message system not initialized")
+	}
+
+	sess, err := store.Get(c)
+	if err != nil {
+		// TODO: Log this
+		fmt.Printf("Error getting session: %v\n", err)
+		return
+	}
+
+	messages := getMessages(sess)
+	messages = append(messages, Message{
+		Text:     text,
+		Severity: severity,
+	})
+
+	sess.Set(flashKey, messages)
+	err = sess.Save()
+
+	if err != nil {
+		// TODO: Log this
+		fmt.Printf("Error saving session: %v\n", err)
+	}
+}
+
+// getMessages retrieves flash messages from the session
+func getMessages(sess *session.Session) []Message {
+	if v := sess.Get(flashKey); v != nil {
+		if messages, ok := v.([]Message); ok {
+			return messages
+		}
+	}
+	return []Message{}
+}
+
+// Debug adds a debug message
+func Debug(c *fiber.Ctx, text string) {
+	AddMessage(c, DEBUG, text)
+}
+
+// Info adds an info message
+func Info(c *fiber.Ctx, text string) {
+	AddMessage(c, INFO, text)
+}
+
+// Success adds a success message
+func Success(c *fiber.Ctx, text string) {
+	AddMessage(c, SUCCESS, text)
+}
+
+// Warning adds a warning message
+func Warning(c *fiber.Ctx, text string) {
+	AddMessage(c, WARNING, text)
+}
+
+// Error adds an error message
+func Error(c *fiber.Ctx, text string) {
+	AddMessage(c, ERROR, text)
+}
+
+// Middleware is a Fiber middleware that handles flash messages
+func Middleware() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		if store == nil {
+			return fiber.NewError(fiber.StatusInternalServerError, "flash message system not initialized")
+		}
+
+		sess, err := store.Get(c)
+		if err != nil {
+			return err
+		}
+
+		if messages := getMessages(sess); len(messages) > 0 {
+			if err := c.Bind(fiber.Map{
+				"flashMessages": messages,
+			}); err != nil {
+				return err
+			}
+
+			// Clear the messages after consuming them
+			sess.Delete(flashKey)
+			if err := sess.Save(); err != nil {
+				return err
+			}
+		}
+
+		return c.Next()
+	}
+}

--- a/handlers/admin_media.go
+++ b/handlers/admin_media.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"codeinstyle.io/captain/config"
+	"codeinstyle.io/captain/flash"
 	"codeinstyle.io/captain/models"
 	"codeinstyle.io/captain/repository"
 	"codeinstyle.io/captain/storage"
@@ -52,9 +53,8 @@ func (h *AdminMediaHandlers) ShowUploadMedia(c *fiber.Ctx) error {
 func (h *AdminMediaHandlers) UploadMedia(c *fiber.Ctx) error {
 	file, err := c.FormFile("file")
 	if err != nil {
-		return c.Status(http.StatusBadRequest).Render("admin_media_upload", fiber.Map{
-			"error": "No file uploaded",
-		})
+		flash.Error(c, "No file uploaded")
+		return c.Status(http.StatusBadRequest).Render("admin_media_upload", fiber.Map{})
 	}
 
 	description := c.FormValue("description")
@@ -62,9 +62,8 @@ func (h *AdminMediaHandlers) UploadMedia(c *fiber.Ctx) error {
 	// Save file using storage provider
 	filename, err := h.storage.Save(file)
 	if err != nil {
-		return c.Status(http.StatusInternalServerError).Render("admin_media_upload", fiber.Map{
-			"error": fmt.Sprintf("Failed to save file: %v", err),
-		})
+		flash.Error(c, fmt.Sprintf("Failed to save file: %v", err))
+		return c.Status(http.StatusInternalServerError).Render("admin_media_upload", fiber.Map{})
 	}
 
 	// Create media record
@@ -79,51 +78,61 @@ func (h *AdminMediaHandlers) UploadMedia(c *fiber.Ctx) error {
 	if err != nil {
 		// Clean up file if database insert fails
 		if err := h.storage.Delete(filename); err != nil {
-			return c.Status(http.StatusInternalServerError).Render("admin_media_upload", fiber.Map{
-				"error": fmt.Sprintf("Failed to delete file: %v", err),
-			})
+			flash.Error(c, fmt.Sprintf("Failed to delete file: %v", err))
+			return c.Status(http.StatusInternalServerError).Render("admin_media_upload", fiber.Map{})
 		}
 
-		return c.Status(http.StatusInternalServerError).Render("admin_media_upload", fiber.Map{
-			"error": fmt.Sprintf("Failed to save media record: %v", err),
-		})
+		flash.Error(c, fmt.Sprintf("Failed to save media record: %v", err))
+		return c.Status(http.StatusInternalServerError).Render("admin_media_upload", fiber.Map{})
 	}
 
+	flash.Success(c, "Media uploaded successfully")
 	return c.Redirect("/admin/media")
 }
 
 // DeleteMedia handles media deletion
 func (h *AdminMediaHandlers) DeleteMedia(c *fiber.Ctx) error {
-	mediaID, err := utils.ParseUint(c.Params("id"))
-
+	id, err := utils.ParseUint(c.Params("id"))
 	if err != nil {
+		flash.Error(c, "Invalid media ID")
 		return c.Status(http.StatusBadRequest).JSON(fiber.Map{
-			"error": "Invalid media ID",
+			"error":    "Invalid media ID",
+			"redirect": "/admin/media",
 		})
 	}
 
-	media, err := h.mediaRepo.FindByID(mediaID)
+	media, err := h.mediaRepo.FindByID(id)
 	if err != nil {
+		flash.Error(c, "Media not found")
 		return c.Status(http.StatusNotFound).JSON(fiber.Map{
-			"error": "Media not found",
+			"error":    "Media not found",
+			"redirect": "/admin/media",
 		})
 	}
 
 	// Delete file using storage provider
 	if err := h.storage.Delete(media.Path); err != nil {
+		flash.Error(c, "Failed to delete media file")
 		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Failed to delete file",
+			"error":    "Failed to delete media file",
+			"redirect": "/admin/media",
 		})
 	}
 
-	// Delete record
+	// Delete media record
 	if err := h.mediaRepo.Delete(media); err != nil {
+		flash.Error(c, "Failed to delete media record")
 		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Failed to delete media record",
+			"error":    "Failed to delete media record",
+			"redirect": "/admin/media",
 		})
 	}
 
-	return c.JSON(fiber.Map{"message": "Media deleted successfully"})
+	flash.Success(c, "Media deleted successfully")
+	return c.JSON(fiber.Map{
+		"message":  "Media deleted successfully",
+		"redirect": "/admin/media",
+	})
 }
 
 // GetMediaList returns a JSON list of media for AJAX requests

--- a/handlers/admin_tags.go
+++ b/handlers/admin_tags.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 
+	"codeinstyle.io/captain/flash"
 	"codeinstyle.io/captain/models"
 	"codeinstyle.io/captain/utils"
 	"github.com/gofiber/fiber/v2"
@@ -18,42 +19,68 @@ type tagResponse struct {
 func (h *AdminHandlers) ListTags(c *fiber.Ctx) error {
 	tags, err := h.repos.Tags.FindPostsAndCount()
 	if err != nil {
-		return c.Status(http.StatusInternalServerError).Render("500", fiber.Map{})
+		flash.Error(c, "Failed to load tags")
+		return c.Status(http.StatusInternalServerError).Render("admin_tags", fiber.Map{})
 	}
 
 	return c.Render("admin_tags", fiber.Map{
-		"tags": tags,
+		"title": "Tags",
+		"tags":  tags,
 	})
 }
 
-// DeleteTag handles the DELETE /admin/tags/:id route
+// DeleteTag handles tag deletion
 func (h *AdminHandlers) DeleteTag(c *fiber.Ctx) error {
 	id, err := utils.ParseUint(c.Params("id"))
 	if err != nil {
-		return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": "Invalid tag ID"})
+		flash.Error(c, "Invalid tag ID")
+		return c.Status(http.StatusBadRequest).JSON(fiber.Map{
+			"error":    "Invalid tag ID",
+			"redirect": "/admin/tags",
+		})
 	}
 
 	tag, err := h.repos.Tags.FindByID(id)
 	if err != nil {
-		return c.Status(http.StatusNotFound).JSON(fiber.Map{"error": "Tag not found"})
+		flash.Error(c, "Tag not found")
+		return c.Status(http.StatusNotFound).JSON(fiber.Map{
+			"error":    "Tag not found",
+			"redirect": "/admin/tags",
+		})
 	}
 
 	// Check if tag has any posts
 	count, err := h.repos.Posts.CountByTag(tag.ID)
 	if err != nil {
-		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": "Failed to check tag usage"})
+		flash.Error(c, "Failed to check tag usage")
+		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{
+			"error":    "Failed to check tag usage",
+			"redirect": "/admin/tags",
+		})
 	}
 
 	if count > 0 {
-		return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": "Cannot delete tag with associated posts"})
+		flash.Error(c, "Cannot delete tag that is still in use")
+		return c.Status(http.StatusBadRequest).JSON(fiber.Map{
+			"error":    "Cannot delete tag that is still in use",
+			"redirect": "/admin/tags",
+		})
 	}
 
 	// Delete tag
 	if err := h.repos.Tags.Delete(tag); err != nil {
-		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": "Failed to delete tag"})
+		flash.Error(c, "Failed to delete tag")
+		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{
+			"error":    "Failed to delete tag",
+			"redirect": "/admin/tags",
+		})
 	}
 
-	return c.JSON(fiber.Map{"message": "Tag deleted successfully"})
+	flash.Success(c, "Tag deleted successfully")
+	return c.JSON(fiber.Map{
+		"message":  "Tag deleted successfully",
+		"redirect": "/admin/tags",
+	})
 }
 
 // ConfirmDeleteTag shows deletion confirmation page for a tag
@@ -76,7 +103,7 @@ func (h *AdminHandlers) ConfirmDeleteTag(c *fiber.Ctx) error {
 // ShowCreateTag handles the GET /admin/tags/create route
 func (h *AdminHandlers) ShowCreateTag(c *fiber.Ctx) error {
 	return c.Render("admin_create_tag", fiber.Map{
-		"tag": &models.Tag{},
+		"title": "Create Tag",
 	})
 }
 
@@ -85,20 +112,21 @@ func (h *AdminHandlers) CreateTag(c *fiber.Ctx) error {
 	tag := new(models.Tag)
 
 	if err := c.BodyParser(tag); err != nil {
+		flash.Error(c, "Invalid form data")
 		return c.Status(http.StatusBadRequest).Render("admin_create_tag", fiber.Map{
-			"tag":   &tag,
-			"error": "Invalid form data",
+			"tag": &tag,
 		})
 	}
 
 	// Create tag
 	if err := h.repos.Tags.Create(tag); err != nil {
+		flash.Error(c, "Failed to create tag")
 		return c.Status(http.StatusInternalServerError).Render("admin_create_tag", fiber.Map{
-			"tag":   &tag,
-			"error": "Failed to create tag",
+			"tag": &tag,
 		})
 	}
 
+	flash.Success(c, "Tag created successfully")
 	return c.Redirect("/admin/tags")
 }
 
@@ -106,16 +134,19 @@ func (h *AdminHandlers) CreateTag(c *fiber.Ctx) error {
 func (h *AdminHandlers) ShowEditTag(c *fiber.Ctx) error {
 	id, err := utils.ParseUint(c.Params("id"))
 	if err != nil {
-		return c.Status(http.StatusBadRequest).Render("500", fiber.Map{})
+		flash.Error(c, "Invalid tag ID")
+		return c.Redirect("/admin/tags")
 	}
 
 	tag, err := h.repos.Tags.FindByID(id)
 	if err != nil {
-		return c.Status(http.StatusNotFound).Render("404", fiber.Map{})
+		flash.Error(c, "Tag not found")
+		return c.Redirect("/admin/tags")
 	}
 
 	return c.Render("admin_edit_tag", fiber.Map{
-		"tag": tag,
+		"title": "Edit Tag",
+		"tag":   tag,
 	})
 }
 
@@ -133,20 +164,21 @@ func (h *AdminHandlers) UpdateTag(c *fiber.Ctx) error {
 
 	// Parse form data
 	if err := c.BodyParser(&tag); err != nil {
+		flash.Error(c, "Invalid form data")
 		return c.Status(http.StatusBadRequest).Render("admin_edit_tag", fiber.Map{
-			"tag":   tag,
-			"error": "Invalid form data",
+			"tag": tag,
 		})
 	}
 
 	// Update tag
 	if err := h.repos.Tags.Update(tag); err != nil {
+		flash.Error(c, "Failed to update tag")
 		return c.Status(http.StatusInternalServerError).Render("admin_edit_tag", fiber.Map{
-			"tag":   tag,
-			"error": "Failed to update tag",
+			"tag": tag,
 		})
 	}
 
+	flash.Success(c, "Tag updated successfully")
 	return c.Redirect("/admin/tags")
 }
 
@@ -154,7 +186,9 @@ func (h *AdminHandlers) UpdateTag(c *fiber.Ctx) error {
 func (h *AdminHandlers) GetTags(c *fiber.Ctx) error {
 	tags, err := h.repos.Tags.FindAll()
 	if err != nil {
-		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": "Failed to fetch tags"})
+		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to load tags",
+		})
 	}
 
 	var response []tagResponse

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 
 	"codeinstyle.io/captain/config"
 	"codeinstyle.io/captain/db"
+	"codeinstyle.io/captain/flash"
 	"codeinstyle.io/captain/handlers"
 	"codeinstyle.io/captain/middleware"
 	"codeinstyle.io/captain/repository"
@@ -103,6 +104,10 @@ func (s *Server) setupRouter(sessionStore *session.Store) error {
 	s.app.Use(middleware.LoadSettings(s.repos))
 	s.app.Use(middleware.LoadVersion(s.repos))
 	s.app.Use(middleware.LoadUserData(s.repos, sessionStore))
+
+	// Initialize flash messages
+	flash.Setup(sessionStore)
+	s.app.Use(flash.Middleware())
 
 	handlers.RegisterPublicRoutes(s.app, s.repos, s.config)
 	handlers.RegisterAuthRoutes(s.app, s.repos, s.config, sessionStore)


### PR DESCRIPTION
# Pull Request

## AI Information
**AI used**: Yes
**Editor used**: Windsurf 1.1.0
**Model used**: Claude 3.5 Sonnet

## Prompts Used

### Prompt 1:
```
Implement a flash message middleware, the middleware populates a variable named "flashMessages" that's injected in templates using ctx.Bind.

The message is composed of:
- message
- Severity

The message is a string, the severity is:

- DEBUG
- INFO
- SUCCESS
- WARNING
- ERROR

The messages are added with flash.flashMessage(flash.DEBUG, "This is a debug message")
On a message has been consumed it's no longer displayed, they are used to notify the user, for example when a post has been successfully created.
```

### Prompt 2:
```
Why would you use gin? The codebase uses fiber
```

### Prompt 3:
```
In @server.go, why would you pass `sessionStore` as a middleware? That doesn't make sense
```
![Screenshot 2024-12-18 at 17 34 50](https://github.com/user-attachments/assets/ef759b6a-53ab-4d68-9add-d8d323e9692c)

### Prompt 4:
```
Expecting to have "session" in c.Locals makes no sense. What you want is storing the messages in the sessionStore
```

At this point instead of using the sessionStore it tried to get an object from Locals: `c.Locals("session")`, obviously that doesn't work.
Also it proposed this code:

```go
if messages := getMessages(sess); len(messages) > 0 {
	c.Locals("flashMessages", messages)
	// Clear the messages after consuming them
	sess.Delete(flashKey)
	if err := sess.Save(); err != nil {
		return err
	}
}
```

Even thought I specifically asked to use `c.Bind`. `c.Bind` injects the data in the rendering engine context to be consumed by templates, `c.Locals` allows to pass data to handlers but you must pass the data down to a `fiber.Map{}` afterwards.

Example:

What's being proposed
```go
func myHandler(c *fiber.Ctx) error {
  // ...some code
  flashMessages := c.Locals("flashMessages")
  c.Render("mypage", fiber.Map{
    "flashMessages": flashMessages,
    // ... the rest of the data
  })
}
```

What I wanted
```go
func myHandler(c *fiber.Ctx) error {
  // ...some code
  c.Render("mypage", fiber.Map{
    "my": "data",
    // ... the data, at this point the "flashMessages" key is already populated by the middleware
  })
}
```

Another issue: this is an example usage provided by the model:

```go
// In your handler
flashMessages := flash.New(sessionStore)
if err := flashMessages.AddMessage(c, flash.SUCCESS, "Post created successfully!"); err != nil {
    return err
}
```

Not very practical, I would rather use

```go
// ... Some code
flashMessages.Add(c, flash.SUCCESS, "Post created successfully!")
```

### Prompt 5:
```
I do NOT want to have write flash.New(sessionStore) every time I want to add a message. Especially since that means passing the sessionStore around
```

### Prompt 6:
```
Following this:

- Add shortcuts to add Messages with the various severity levels, for example flash.Success(c, "My message") is equivalent to flash.AddMessage(c,flash.SUCCESS, "My message")
- In the admin handlers @admin_menu.go @admin_settings.go @admin_tags.go @admin_media.go @admin_pages.go @admin_posts.go @admin_users.go @admin.go use messages instead of passing "error" in the rendering context.
- Update the @admin_header.tmpl to display the messages (they should be dismissible by the user)
```

### Prompt 7:
```
Please limit yourself to removing the "error" in the rendering data and add flash messages instead, you changed a lot of logic that was perfectly fine.
```

It generated a lot of breaking changes so I add to reject the changes in `admin_posts.go` and did them by hand. The rest of the code was fine though. Except for the Delete* logic, which relies on a successful json response to redirect the user to the index page 

Please note that the Cascade asks for confirmation do continue with the rest of the changes, despite having listed the list of file to be updated in my prompt 7, it stopped leaving `admin_menu.go` and `admin_settings.go` unedited.

### Prompt 8:
```
You did not edit @admin_menu.go and @admin_settings.go 
```

### Prompt 9:
```
In @admin.js the `deleteTag`, `deletePost`, etc... have hardcoded url redirects in them, update the delete handlers to return JSON, pass the redirection url in the payload and use said payload in @admin.js  to redirect the user properly. Remove the `showError` method and its usage since they duplicate the behavior of flash messages
```

### Prompt 10:
```
In @admin_tags.go please use the existing Posts.CountByTag instead of referencing an inexisting Tags.CountPostsWithTag method
```

### Prompt 11:
```
In @admin_users.go and @admin.js please use the same delete logic by adding the corresponding function in the javascript and return json where applicable. The deleteUser function doesn't exist
```

### Prompt 12:
```
@flash.go You used `c.Locals` in the Middleware and I asked for `c.Bind`
```

Code produced:

```go
c.Locals("flashMessages", messages)
```

Wanted:

```go
c.Bind(fiber.Map{
	"flashMessages": messages,
})
```

### Prompt 13:
```
The argument passed to c.Bind must be fiber.Map{}
```

### Prompt 14:
```
You created a new include template for the flash messages but also inserted the code directly into @admin_header.tmpl, remove the code in @admin_header.html
```

### Prompt 15:
```
Add a e2e step that checks that a message is displayed after creating a post
```

### Prompt 16:
```
The css class used in the test is wrong, use @admin_header.tmpl for reference
```

## Description
This adds flash messages that can displayed after an action or an error.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [x] Integration Tests
- [x] Manual Testing

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


